### PR TITLE
Bump runtime to 49

### DIFF
--- a/org.gabmus.notorious.json
+++ b/org.gabmus.notorious.json
@@ -2,7 +2,7 @@
     "app-id": "org.gabmus.notorious",
     "command": "notorious",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "finish-args": [
         "--device=dri",
@@ -13,6 +13,20 @@
     ],
     "modules": [
         {
+            "name": "gtksourceview-git",
+            "buildsystem": "meson",
+            "config-opts": [
+                "--buildtype=release"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtksourceview",
+                    "commit": "7fd3adb3134bbec167167bb6400e018e4f781eb9"
+                }
+            ]
+        },
+	{
             "name": "otf-source-code-pro",
             "buildsystem": "simple",
             "sources": [

--- a/screenshot.patch
+++ b/screenshot.patch
@@ -16,27 +16,27 @@ index c6c7d8c..939ebcf 100644
      <screenshots>
          <screenshot type="default">
 -            <image>https://gitlab.gnome.org/gabmus/notorious/raw/website/website/screenshots/mainwindow-light.png</image>
-+            <image>https://raw.githubusercontent.com/bbhtt/org.gabmus.notorious/runtime-44/screenshots/screenshot1.png</image>
++            <image>https://img.linuxphoneapps.org/flathub/org.gabmus.notorious/screenshot1.png</image>
          </screenshot>
          <screenshot>
 -            <image>https://gitlab.gnome.org/gabmus/notorious/raw/website/website/screenshots/mainwindow.png</image>
-+            <image>https://raw.githubusercontent.com/bbhtt/org.gabmus.notorious/runtime-44/screenshots/screenshot2.png</image>
++            <image>https://img.linuxphoneapps.org/flathub/org.gabmus.notorious/screenshot2.png</image>
          </screenshot>
          <screenshot>
 -            <image>https://gabmus.gitlab.io/notorious/screenshots/keyboard_shortcuts-light.png</image>
-+            <image>https://raw.githubusercontent.com/bbhtt/org.gabmus.notorious/runtime-44/screenshots/screenshot3.png</image>
++            <image>https://img.linuxphoneapps.org/flathub/org.gabmus.notorious/screenshot3.png</image>
          </screenshot>
          <screenshot>
 -            <image>https://gabmus.gitlab.io/notorious/screenshots/markdown-light.png</image>
-+            <image>https://raw.githubusercontent.com/bbhtt/org.gabmus.notorious/runtime-44/screenshots/screenshot4.png</image>
++            <image>https://img.linuxphoneapps.org/flathub/org.gabmus.notorious/screenshot4.png</image>
          </screenshot>
          <screenshot>
 -            <image>https://gabmus.gitlab.io/notorious/screenshots/darkmode.png</image>
-+            <image>https://raw.githubusercontent.com/bbhtt/org.gabmus.notorious/runtime-44/screenshots/screenshot5.png</image>
++            <image>https://img.linuxphoneapps.org/flathub/org.gabmus.notorious/screenshot5.png</image>
          </screenshot>
          <screenshot>
 -            <image>https://gabmus.gitlab.io/notorious/screenshots/markdown.png</image>
-+            <image>https://raw.githubusercontent.com/bbhtt/org.gabmus.notorious/runtime-44/screenshots/screenshot6.png</image>
++            <image>https://img.linuxphoneapps.org/flathub/org.gabmus.notorious/screenshot6.png</image>
          </screenshot>
      </screenshots>
      <url type="homepage">https://notorious.gabmus.org</url>


### PR DESCRIPTION
Bumping the runtime to  49.

Also including the latest 4.x release of gtksourceview, as it is not part of the GNOME 49 runtime:

https://gitlab.gnome.org/GNOME/gtksourceview/-/commit/7fd3adb3134bbec167167bb6400e018e4f781eb9